### PR TITLE
Fix returns on finalize and update_frac

### DIFF
--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_c.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_c.pyx
@@ -109,15 +109,15 @@ cdef class {{ pymt_class }}:
         ok_or_raise(status)
 
     def update_frac(self, frac):
-        ok_or_raise(<int>bmi_update_frac(self._bmi, frac))
-        return <int>bmi_update_frac(self._bmi, frac), None
+        status = <int>bmi_update_frac(self._bmi, frac)
+        ok_or_raise(status)
 
     def run_model(self):
         ok_or_raise(<int>bmi_run_model(self._bmi))
 
     def finalize(self):
-        ok_or_raise(<int>bmi_finalize(self._bmi))
-        return <int>bmi_finalize(self._bmi), None
+        status = <int>bmi_finalize(self._bmi)
+        ok_or_raise(status)
 
     cpdef object get_component_name(self):
         ok_or_raise(<int>bmi_get_component_name(self._bmi, self.STR_BUFFER))


### PR DESCRIPTION
To match the implementation (and style) of `initialize` and `update`, I removed the return statement from `finalize` and `update_frac`.

This fixes https://github.com/pymt-lab/pymt_hydrotrend/issues/2, although the recipe will have to be regenerated.