### PR TITLE
Fix "Directory not empty" error on Linux

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+import errno
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -37,7 +38,7 @@ def clean_folder(folderpath, keep=None):
     try:
         folderpath.rmdir()
     except OSError as err:
-        if err.errno != 66: # 66 means the folder isn't empty.
+        if err.errno != errno.ENOTEMPTY:
             raise
 
 


### PR DESCRIPTION
This pull request fixes a problem when running the post hook on Linux. It turns our the errno code for "Directory not empty" is different on different platforms. Instead of using the numeric value, use `errno.ENOTEMPTY` instead. It's way more readable anyway.

The addresses csdms/bmi_wrap#6.
