### PR TITLE
Templatize Fortran BMI wrapper

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "plugin_requirements": "",
   "plugin_module": "plugin",
   "plugin_class": "{{ cookiecutter.plugin_name|title }}",
-  "language": ["c", "c++", "python"],
+  "language": ["c", "c++", "fortran", "python"],
   "pymt_class": "{{ cookiecutter.plugin_class }}",
   "bmi_register": "bmi_register_{{ cookiecutter.plugin_name }}",
   "undef_macros": "",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -95,6 +95,12 @@ if __name__ == "__main__":
     keep |= set(["__init__.py", "bmi.hxx"])
     keep |= split_file(LIB_DIRECTORY / "_cxx.pyx", include_preamble=True)
 
+    {%- elif cookiecutter.language == 'fortran' %}
+
+    keep |= set(["__init__.py", "bmi.f90", "bmi_interoperability.f90",
+                 "bmi_interoperability.h"])
+    keep |= split_file(LIB_DIRECTORY / "_fortran.pyx", include_preamble=True)
+
     {%- endif %}
 
     clean_folder(LIB_DIRECTORY, keep=keep)

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/bmi.py
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/bmi.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import
     {% set _ = classes.append(pymt_class) %}
 {%- endfor -%}
 
-{%- if cookiecutter.language == 'c' or cookiecutter.language == 'c++' %}
+{%- if cookiecutter.language == 'c' or cookiecutter.language == 'c++'
+ or cookiecutter.language == 'fortran' %}
 
 from .lib import {{ classes|join(', ') }}
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/bmi.py
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/bmi.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import
     {% set _ = classes.append(pymt_class) %}
 {%- endfor -%}
 
-{%- if cookiecutter.language == 'c' or cookiecutter.language == 'c++'
- or cookiecutter.language == 'fortran' %}
+{%- if cookiecutter.language in ['c', 'c++', 'fortran'] %}
 
 from .lib import {{ classes|join(', ') }}
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -88,7 +88,7 @@ cpdef to_string(bytes):
 
 {%- set entry_point = cookiecutter.entry_points.split(',')[0] -%}
 {% set pymt_class = entry_point.split('=')[0] %}
-{% set plugin_module, register_bmi = entry_point.split('=')[1].split(':') %}
+{% set plugin_module, plugin_class = entry_point.split('=')[1].split(':') %}
 
 # start: {{ pymt_class|lower }}.pyx
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -80,11 +80,17 @@ def ok_or_raise(status):
 
 
 cpdef to_bytes(string):
-    return bytes(string.encode('utf-8'))
+    try:
+        return bytes(string.encode('utf-8'))
+    except AttributeError:
+        return string
 
 
 cpdef to_string(bytes):
-    return bytes.decode('utf-8').rstrip()
+    try:
+        return bytes.decode('utf-8').rstrip()
+    except AttributeError:
+        return bytes
 
 {%- set entry_point = cookiecutter.entry_points.split(',')[0] -%}
 {% set pymt_class = entry_point.split('=')[0] %}

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -427,3 +427,4 @@ cdef class {{ pymt_class }}:
                                                  len(var_name),
                                                  buffer.data,
                                                  grid_size))
+        return buffer

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -1,7 +1,21 @@
+import ctypes
 from libc.stdlib cimport malloc, free
 
 cimport numpy as np
 import numpy as np
+
+
+SIZEOF_FLOAT = 8 * ctypes.sizeof(ctypes.c_float)
+SIZEOF_DOUBLE = 8 * ctypes.sizeof(ctypes.c_double)
+SIZEOF_INT = 8 * ctypes.sizeof(ctypes.c_int)
+
+DTYPE_F_TO_PY = {
+    'real': 'float{bits}'.format(bits=SIZEOF_FLOAT),
+    'real*4': 'float{bits}'.format(bits=SIZEOF_FLOAT),
+    'double precision': 'float{bits}'.format(bits=SIZEOF_DOUBLE),
+    'real*8': 'float{bits}'.format(bits=SIZEOF_DOUBLE),
+    'integer': 'int{bits}'.format(bits=SIZEOF_INT),
+}
 
 
 cdef extern from "bmi_interoperability.h":
@@ -322,7 +336,7 @@ cdef class {{ pymt_class }}:
                                           len(var_name),
                                           self.STR_BUFFER,
                                           MAX_TYPE_NAME))
-        return to_string(self.STR_BUFFER)
+        return DTYPE_F_TO_PY[to_string(self.STR_BUFFER)]
 
     cpdef object get_var_units(self, var_name):
         self.reset_str_buffer()

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -90,6 +90,8 @@ cpdef to_string(bytes):
 {% set pymt_class = entry_point.split('=')[0] %}
 {% set plugin_module, register_bmi = entry_point.split('=')[1].split(':') %}
 
+# start: {{ pymt_class|lower }}.pyx
+
 cdef class {{ pymt_class }}:
 
     cdef int _bmi

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -86,7 +86,7 @@ cpdef to_bytes(string):
 cpdef to_string(bytes):
     return bytes.decode('utf-8').rstrip()
 
-{% set entry_point = cookiecutter.entry_points.split(',')[0] %}
+{%- set entry_point = cookiecutter.entry_points.split(',')[0] -%}
 {% set pymt_class = entry_point.split('=')[0] %}
 {% set plugin_module, register_bmi = entry_point.split('=')[1].split(':') %}
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -1,5 +1,3 @@
-# cython: c_string_type=str, c_string_encoding=ascii
-
 from libc.stdlib cimport malloc, free
 
 cimport numpy as np

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -51,11 +51,11 @@ cdef extern from "bmi_interoperability.h":
     int bmi_get_grid_rank(int model, int grid_id, int *rank)
     int bmi_get_grid_shape(int model, int grid_id, int *shape, int rank)
     int bmi_get_grid_size(int model, int grid_id, int *size)
-    int bmi_get_grid_spacing(int model, int grid_id, float *spacing, int rank)
-    int bmi_get_grid_origin(int model, int grid_id, float *origin, int rank)
-    int bmi_get_grid_x(int model, int grid_id, float *x, int size)
-    int bmi_get_grid_y(int model, int grid_id, float *y, int size)
-    int bmi_get_grid_z(int model, int grid_id, float *z, int size)
+    int bmi_get_grid_spacing(int model, int grid_id, double *spacing, int rank)
+    int bmi_get_grid_origin(int model, int grid_id, double *origin, int rank)
+    int bmi_get_grid_x(int model, int grid_id, double *x, int size)
+    int bmi_get_grid_y(int model, int grid_id, double *y, int size)
+    int bmi_get_grid_z(int model, int grid_id, double *z, int size)
     int bmi_get_grid_connectivity(int model, int grid_id, int *conn, int size)
     int bmi_get_grid_offset(int model, int grid_id, int *offset, int size)
 
@@ -281,35 +281,35 @@ cdef class {{ pymt_class }}:
         return shape
 
     cpdef np.ndarray get_grid_spacing(self, grid_id, \
-                                      np.ndarray[float, ndim=1] spacing):
+                                      np.ndarray[double, ndim=1] spacing):
         cdef int rank = self.get_grid_rank(grid_id)
         ok_or_raise(<int>bmi_get_grid_spacing(self._bmi, grid_id,
                                               &spacing[0], rank))
         return spacing
 
     cpdef np.ndarray get_grid_origin(self, grid_id, \
-                                     np.ndarray[float, ndim=1] origin):
+                                     np.ndarray[double, ndim=1] origin):
         cdef int rank = self.get_grid_rank(grid_id)
         ok_or_raise(<int>bmi_get_grid_origin(self._bmi, grid_id,
                                              &origin[0], rank))
         return origin
 
     cpdef np.ndarray get_grid_x(self, grid_id, \
-                                np.ndarray[float, ndim=1] grid_x):
+                                np.ndarray[double, ndim=1] grid_x):
         cdef int size = self.get_grid_size(grid_id)
         ok_or_raise(<int>bmi_get_grid_x(self._bmi, grid_id,
                                         &grid_x[0], size))
         return grid_x
 
     cpdef np.ndarray get_grid_y(self, grid_id, \
-                                np.ndarray[float, ndim=1] grid_y):
+                                np.ndarray[double, ndim=1] grid_y):
         cdef int size = self.get_grid_size(grid_id)
         ok_or_raise(<int>bmi_get_grid_y(self._bmi, grid_id,
                                         &grid_y[0], size))
         return grid_y
 
     cpdef np.ndarray get_grid_z(self, grid_id, \
-                                np.ndarray[float, ndim=1] grid_z):
+                                np.ndarray[double, ndim=1] grid_z):
         cdef int size = self.get_grid_size(grid_id)
         ok_or_raise(<int>bmi_get_grid_z(self._bmi, grid_id,
                                         &grid_z[0], size))

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -75,8 +75,8 @@ cdef extern from "bmi_interoperability.h":
     int bmi_get_value_double(int model, const char *var_name, int n_chars,
                              void *buffer, int size)
 
-    int bmi_get_value_ref(int model, const char *var_name,
-                          int n_chars, void **ref)
+    int bmi_get_value_ptr(int model, const char *var_name,
+                          int n_chars, void **ptr)
 
     int bmi_set_value_int(int model, const char *var_name, int n_chars,
                           void *buffer, int size)
@@ -387,13 +387,13 @@ cdef class {{ pymt_class }}:
 
         return buffer
 
-    cpdef np.ndarray get_value_ref(self, var_name):
+    cpdef np.ndarray get_value_ptr(self, var_name):
         cdef int grid_id = self.get_var_grid(var_name)
         cdef int grid_size = self.get_grid_size(grid_id)
         cdef void* ptr
         type = self.get_var_type(var_name)
 
-        ok_or_raise(<int>bmi_get_value_ref(self._bmi,
+        ok_or_raise(<int>bmi_get_value_ptr(self._bmi,
                                            to_bytes(var_name),
                                            len(var_name), &ptr))
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -1,0 +1,409 @@
+# cython: c_string_type=str, c_string_encoding=ascii
+
+from libc.stdlib cimport malloc, free
+
+cimport numpy as np
+import numpy as np
+
+
+cdef extern from "bmi_interoperability.h":
+    int MAX_COMPONENT_NAME
+    int MAX_VAR_NAME
+    int MAX_TYPE_NAME
+    int MAX_UNITS_NAME
+
+    int bmi_new()
+
+    int bmi_initialize(int model, const char *config_file, int n_chars)
+    int bmi_update(int model)
+    int bmi_update_until(int model, double until)
+    int bmi_update_frac(int model, double frac)
+    int bmi_finalize(int model)
+
+    int bmi_get_component_name(int model, char *name, int n_chars)
+    int bmi_get_input_var_name_count(int model, int *count)
+    int bmi_get_output_var_name_count(int model, int *count)
+    int bmi_get_input_var_names(int model, char **names, int n_names)
+    int bmi_get_output_var_names(int model, char **names, int n_names)
+
+    int bmi_get_start_time(int model, double *time)
+    int bmi_get_end_time(int model, double *time)
+    int bmi_get_current_time(int model, double *time)
+    int bmi_get_time_step(int model, double *time)
+    int bmi_get_time_units(int model, char *units, int n_chars)
+
+    int bmi_get_var_grid(int model, const char *var_name, int n_chars,
+                         int *grid_id)
+
+    int bmi_get_grid_type(int model, int grid_id, char *type, int n_chars)
+    int bmi_get_grid_rank(int model, int grid_id, int *rank)
+    int bmi_get_grid_shape(int model, int grid_id, int *shape, int rank)
+    int bmi_get_grid_size(int model, int grid_id, int *size)
+    int bmi_get_grid_spacing(int model, int grid_id, float *spacing, int rank)
+    int bmi_get_grid_origin(int model, int grid_id, float *origin, int rank)
+    int bmi_get_grid_x(int model, int grid_id, float *x, int size)
+    int bmi_get_grid_y(int model, int grid_id, float *y, int size)
+    int bmi_get_grid_z(int model, int grid_id, float *z, int size)
+    int bmi_get_grid_connectivity(int model, int grid_id, int *conn, int size)
+    int bmi_get_grid_offset(int model, int grid_id, int *offset, int size)
+
+    int bmi_get_var_type(int model, const char *var_name, int n_chars,
+                         char *type, int m_chars)
+    int bmi_get_var_units(int model, const char *var_name, int n_chars,
+                          char *units, int m_chars)
+    int bmi_get_var_itemsize(int model, const char *var_name,
+                             int n_chars, int *itemsize)
+    int bmi_get_var_nbytes(int model, const char *var_name,
+                           int n_chars, int *nbytes)
+
+    int bmi_get_value_int(int model, const char *var_name, int n_chars,
+                          void *buffer, int size)
+    int bmi_get_value_float(int model, const char *var_name, int n_chars,
+                            void *buffer, int size)
+    int bmi_get_value_double(int model, const char *var_name, int n_chars,
+                             void *buffer, int size)
+
+    int bmi_get_value_ref(int model, const char *var_name,
+                          int n_chars, void **ref)
+
+    int bmi_set_value_int(int model, const char *var_name, int n_chars,
+                          void *buffer, int size)
+    int bmi_set_value_float(int model, const char *var_name, int n_chars,
+                            void *buffer, int size)
+    int bmi_set_value_double(int model, const char *var_name, int n_chars,
+                             void *buffer, int size)
+
+
+def ok_or_raise(status):
+    if status != 0:
+        raise RuntimeError('error code {status}'.format(status=status))
+
+
+cpdef to_bytes(string):
+    return bytes(string.encode('utf-8'))
+
+
+cpdef to_string(bytes):
+    return bytes.decode('utf-8').rstrip()
+
+{% set entry_point = cookiecutter.entry_points.split(',')[0] %}
+{% set pymt_class = entry_point.split('=')[0] %}
+{% set plugin_module, register_bmi = entry_point.split('=')[1].split(':') %}
+
+cdef class {{ pymt_class }}:
+
+    cdef int _bmi
+    cdef char[2048] STR_BUFFER
+
+    def __cinit__(self):
+        self._bmi = bmi_new()
+
+        if self._bmi < 0:
+            raise MemoryError('out of range model index: {}'
+                              .format(self._bmi))
+
+    cpdef int _get_model_index(self):
+        return self._bmi
+
+    cdef void reset_str_buffer(self):
+        self.STR_BUFFER = np.zeros(MAX_VAR_NAME, dtype=np.byte)
+
+    def initialize(self, config_file):
+        status = <int>bmi_initialize(self._bmi, to_bytes(config_file),
+                                     len(config_file))
+        ok_or_raise(status)
+
+    def finalize(self):
+        status = <int>bmi_finalize(self._bmi)
+        self._bmi = -1
+        ok_or_raise(status)
+
+    cpdef object get_component_name(self):
+        self.reset_str_buffer()
+        ok_or_raise(<int>bmi_get_component_name(self._bmi,
+                                                self.STR_BUFFER,
+                                                MAX_COMPONENT_NAME))
+        return to_string(self.STR_BUFFER)
+
+    cpdef int get_input_var_name_count(self):
+        cdef int count = 0
+        ok_or_raise(<int>bmi_get_input_var_name_count(self._bmi, &count))
+        return count
+
+    cpdef object get_input_var_names(self):
+        cdef list py_names = []
+        cdef char** names
+        cdef int i
+        cdef int count
+        cdef int status = 1
+
+        ok_or_raise(<int>bmi_get_input_var_name_count(self._bmi, &count))
+
+        try:
+            names = <char**>malloc(count * sizeof(char*))
+            names[0] = <char*>malloc(count * MAX_VAR_NAME * sizeof(char))
+            for i in range(1, count):
+                names[i] = names[i - 1] + MAX_VAR_NAME
+
+            ok_or_raise(<int>bmi_get_input_var_names(self._bmi, names, count))
+
+            for i in range(count):
+                py_names.append(to_string(names[i]))
+
+        except Exception:
+            raise
+
+        finally:
+            free(names)
+
+        return tuple(py_names)
+
+    cpdef int get_output_var_name_count(self):
+        cdef int count = 0
+        ok_or_raise(<int>bmi_get_output_var_name_count(self._bmi, &count))
+        return count
+
+    cpdef object get_output_var_names(self):
+        cdef list py_names = []
+        cdef char** names
+        cdef int i
+        cdef int count
+        cdef int status = 1
+
+        ok_or_raise(<int>bmi_get_output_var_name_count(self._bmi, &count))
+
+        try:
+            names = <char**>malloc(count * sizeof(char*))
+            names[0] = <char*>malloc(count * MAX_VAR_NAME * sizeof(char))
+            for i in range(1, count):
+                names[i] = names[i - 1] + MAX_VAR_NAME
+
+            ok_or_raise(<int>bmi_get_output_var_names(self._bmi, names, count))
+
+            for i in range(count):
+                py_names.append(to_string(names[i]))
+
+        except Exception:
+            raise
+
+        finally:
+            free(names)
+
+        return tuple(py_names)
+
+    cpdef double get_start_time(self):
+        cdef double time
+        ok_or_raise(<int>bmi_get_start_time(self._bmi, &time))
+        return time
+
+    cpdef double get_end_time(self):
+        cdef double time
+        ok_or_raise(<int>bmi_get_end_time(self._bmi, &time))
+        return time
+
+    cpdef double get_current_time(self):
+        cdef double time
+        ok_or_raise(<int>bmi_get_current_time(self._bmi, &time))
+        return time
+
+    cpdef double get_time_step(self):
+        cdef double step
+        ok_or_raise(<int>bmi_get_time_step(self._bmi, &step))
+        return step
+
+    cpdef object get_time_units(self):
+        self.reset_str_buffer()
+        ok_or_raise(<int>bmi_get_time_units(self._bmi, self.STR_BUFFER,
+                                            MAX_UNITS_NAME))
+        return to_string(self.STR_BUFFER)
+
+    cpdef update(self):
+        status = <int>bmi_update(self._bmi)
+        ok_or_raise(status)
+
+    cpdef update_frac(self, time_frac):
+        status = <int>bmi_update_frac(self._bmi, time_frac)
+        ok_or_raise(status)
+
+    cpdef update_until(self, time_later):
+        status = <int>bmi_update_until(self._bmi, time_later)
+        ok_or_raise(status)
+
+    cpdef int get_var_grid(self, var_name):
+        cdef int grid_id
+        ok_or_raise(<int>bmi_get_var_grid(self._bmi,
+                                          to_bytes(var_name),
+                                          len(var_name), &grid_id))
+        return grid_id
+
+    cpdef object get_grid_type(self, grid_id):
+        self.reset_str_buffer()
+        ok_or_raise(<int>bmi_get_grid_type(self._bmi, grid_id,
+                                           self.STR_BUFFER,
+                                           MAX_TYPE_NAME))
+        return to_string(self.STR_BUFFER)
+
+    cpdef int get_grid_rank(self, grid_id):
+        cdef int rank
+        ok_or_raise(<int>bmi_get_grid_rank(self._bmi, grid_id, &rank))
+        return rank
+
+    cpdef int get_grid_size(self, grid_id):
+        cdef int size
+        ok_or_raise(<int>bmi_get_grid_size(self._bmi, grid_id, &size))
+        return size
+
+    cpdef np.ndarray get_grid_shape(self, grid_id, \
+                                    np.ndarray[int, ndim=1] shape):
+        cdef int rank = self.get_grid_rank(grid_id)
+        ok_or_raise(<int>bmi_get_grid_shape(self._bmi, grid_id,
+                                            &shape[0], rank))
+        return shape
+
+    cpdef np.ndarray get_grid_spacing(self, grid_id, \
+                                      np.ndarray[float, ndim=1] spacing):
+        cdef int rank = self.get_grid_rank(grid_id)
+        ok_or_raise(<int>bmi_get_grid_spacing(self._bmi, grid_id,
+                                              &spacing[0], rank))
+        return spacing
+
+    cpdef np.ndarray get_grid_origin(self, grid_id, \
+                                     np.ndarray[float, ndim=1] origin):
+        cdef int rank = self.get_grid_rank(grid_id)
+        ok_or_raise(<int>bmi_get_grid_origin(self._bmi, grid_id,
+                                             &origin[0], rank))
+        return origin
+
+    cpdef np.ndarray get_grid_x(self, grid_id, \
+                                np.ndarray[float, ndim=1] grid_x):
+        cdef int size = self.get_grid_size(grid_id)
+        ok_or_raise(<int>bmi_get_grid_x(self._bmi, grid_id,
+                                        &grid_x[0], size))
+        return grid_x
+
+    cpdef np.ndarray get_grid_y(self, grid_id, \
+                                np.ndarray[float, ndim=1] grid_y):
+        cdef int size = self.get_grid_size(grid_id)
+        ok_or_raise(<int>bmi_get_grid_y(self._bmi, grid_id,
+                                        &grid_y[0], size))
+        return grid_y
+
+    cpdef np.ndarray get_grid_z(self, grid_id, \
+                                np.ndarray[float, ndim=1] grid_z):
+        cdef int size = self.get_grid_size(grid_id)
+        ok_or_raise(<int>bmi_get_grid_z(self._bmi, grid_id,
+                                        &grid_z[0], size))
+        return grid_z
+
+    cpdef np.ndarray get_grid_connectivity(self, grid_id, \
+                                           np.ndarray[int, ndim=1] conn):
+        cdef int size = self.get_grid_size(grid_id)
+        ok_or_raise(<int>bmi_get_grid_connectivity(self._bmi, grid_id,
+                                                   &conn[0], size))
+        return conn
+
+    cpdef np.ndarray get_grid_offset(self, grid_id, 
+                                     np.ndarray[int, ndim=1] offset):
+        cdef int size = self.get_grid_size(grid_id)
+        ok_or_raise(<int>bmi_get_grid_offset(self._bmi, grid_id,
+                                             &offset[0], size))
+        return offset
+
+    cpdef object get_var_type(self, var_name):
+        self.reset_str_buffer()
+        ok_or_raise(<int>bmi_get_var_type(self._bmi,
+                                          to_bytes(var_name),
+                                          len(var_name),
+                                          self.STR_BUFFER,
+                                          MAX_TYPE_NAME))
+        return to_string(self.STR_BUFFER)
+
+    cpdef object get_var_units(self, var_name):
+        self.reset_str_buffer()
+        ok_or_raise(<int>bmi_get_var_units(self._bmi,
+                                           to_bytes(var_name),
+                                           len(var_name),
+                                           self.STR_BUFFER,
+                                           MAX_UNITS_NAME))
+        return to_string(self.STR_BUFFER)
+
+    cpdef int get_var_itemsize(self, var_name):
+        cdef int itemsize
+        ok_or_raise(<int>bmi_get_var_itemsize(self._bmi,
+                                              to_bytes(var_name),
+                                              len(var_name), &itemsize))
+        return itemsize
+
+    cpdef int get_var_nbytes(self, var_name):
+        cdef int nbytes
+        ok_or_raise(<int>bmi_get_var_nbytes(self._bmi,
+                                            to_bytes(var_name),
+                                            len(var_name), &nbytes))
+        return nbytes
+
+    cpdef np.ndarray get_value(self, var_name, np.ndarray buffer):
+        cdef int grid_id = self.get_var_grid(var_name)
+        cdef int grid_size = self.get_grid_size(grid_id)
+        type = self.get_var_type(var_name)
+
+        if type.startswith('double'):
+            ok_or_raise(<int>bmi_get_value_double(self._bmi,
+                                                  to_bytes(var_name),
+                                                  len(var_name),
+                                                  buffer.data,
+                                                  grid_size))
+        elif type.startswith('int'):
+            ok_or_raise(<int>bmi_get_value_int(self._bmi,
+                                               to_bytes(var_name),
+                                               len(var_name),
+                                               buffer.data,
+                                               grid_size))
+        else:
+            ok_or_raise(<int>bmi_get_value_float(self._bmi,
+                                                 to_bytes(var_name),
+                                                 len(var_name),
+                                                 buffer.data,
+                                                 grid_size))
+
+        return buffer
+
+    cpdef np.ndarray get_value_ref(self, var_name):
+        cdef int grid_id = self.get_var_grid(var_name)
+        cdef int grid_size = self.get_grid_size(grid_id)
+        cdef void* ptr
+        type = self.get_var_type(var_name)
+
+        ok_or_raise(<int>bmi_get_value_ref(self._bmi,
+                                           to_bytes(var_name),
+                                           len(var_name), &ptr))
+
+        if type.startswith('double'):
+            return np.asarray(<np.float64_t[:grid_size]>ptr)
+        elif type.startswith('int'):
+            return np.asarray(<np.int32_t[:grid_size]>ptr)
+        else:
+            return np.asarray(<np.float32_t[:grid_size]>ptr)
+
+    cpdef set_value(self, var_name, np.ndarray buffer):
+        cdef int grid_id = self.get_var_grid(var_name)
+        cdef int grid_size = self.get_grid_size(grid_id)
+        type = self.get_var_type(var_name)
+
+        if type.startswith('double'):
+            ok_or_raise(<int>bmi_set_value_double(self._bmi,
+                                                  to_bytes(var_name),
+                                                  len(var_name),
+                                                  buffer.data,
+                                                  grid_size))
+        elif type.startswith('int'):
+            ok_or_raise(<int>bmi_set_value_int(self._bmi,
+                                               to_bytes(var_name),
+                                               len(var_name),
+                                               buffer.data,
+                                               grid_size))
+        else:
+            ok_or_raise(<int>bmi_set_value_float(self._bmi,
+                                                 to_bytes(var_name),
+                                                 len(var_name),
+                                                 buffer.data,
+                                                 grid_size))

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi.f90
@@ -1,0 +1,469 @@
+module bmif
+
+  implicit none
+
+  integer, parameter :: BMI_MAX_COMPONENT_NAME = 2048
+  integer, parameter :: BMI_MAX_VAR_NAME = 2048
+  integer, parameter :: BMI_MAX_TYPE_NAME = 2048
+  integer, parameter :: BMI_MAX_UNITS_NAME = 2048
+
+  integer, parameter :: BMI_FAILURE = 1
+  integer, parameter :: BMI_SUCCESS = 0
+
+  type, abstract :: bmi
+     contains
+       procedure (bmif_get_component_name), deferred :: get_component_name
+       procedure (bmif_get_input_var_names), deferred :: get_input_var_names
+       procedure (bmif_get_output_var_names), deferred :: get_output_var_names
+       procedure (bmif_initialize), deferred :: initialize
+       procedure (bmif_finalize), deferred :: finalize
+       procedure (bmif_get_start_time), deferred :: get_start_time
+       procedure (bmif_get_end_time), deferred :: get_end_time
+       procedure (bmif_get_current_time), deferred :: get_current_time
+       procedure (bmif_get_time_step), deferred :: get_time_step
+       procedure (bmif_get_time_units), deferred :: get_time_units
+       procedure (bmif_update), deferred :: update
+       procedure (bmif_update_frac), deferred :: update_frac
+       procedure (bmif_update_until), deferred :: update_until
+       procedure (bmif_get_var_grid), deferred :: get_var_grid
+       procedure (bmif_get_grid_type), deferred :: get_grid_type
+       procedure (bmif_get_grid_rank), deferred :: get_grid_rank
+       procedure (bmif_get_grid_shape), deferred :: get_grid_shape
+       procedure (bmif_get_grid_size), deferred :: get_grid_size
+       procedure (bmif_get_grid_spacing), deferred :: get_grid_spacing
+       procedure (bmif_get_grid_origin), deferred :: get_grid_origin
+       procedure (bmif_get_grid_x), deferred :: get_grid_x
+       procedure (bmif_get_grid_y), deferred :: get_grid_y
+       procedure (bmif_get_grid_z), deferred :: get_grid_z
+       procedure (bmif_get_grid_connectivity), deferred :: get_grid_connectivity
+       procedure (bmif_get_grid_offset), deferred :: get_grid_offset
+       procedure (bmif_get_var_type), deferred :: get_var_type
+       procedure (bmif_get_var_units), deferred :: get_var_units
+       procedure (bmif_get_var_itemsize), deferred :: get_var_itemsize
+       procedure (bmif_get_var_nbytes), deferred :: get_var_nbytes
+       procedure (bmif_get_value_int), deferred :: get_value_int
+       procedure (bmif_get_value_float), deferred :: get_value_float
+       procedure (bmif_get_value_double), deferred :: get_value_double
+       procedure (bmif_get_value_ref_int), deferred :: get_value_ref_int
+       procedure (bmif_get_value_ref_float), deferred :: get_value_ref_float
+       procedure (bmif_get_value_ref_double), deferred :: get_value_ref_double
+       procedure (bmif_get_value_at_indices_int), deferred :: &
+            get_value_at_indices_int
+       procedure (bmif_get_value_at_indices_float), deferred :: &
+            get_value_at_indices_float
+       procedure (bmif_get_value_at_indices_double), deferred :: &
+            get_value_at_indices_double
+       procedure (bmif_set_value_int), deferred :: set_value_int
+       procedure (bmif_set_value_float), deferred :: set_value_float
+       procedure (bmif_set_value_double), deferred :: set_value_double
+       procedure (bmif_set_value_at_indices_int), deferred :: &
+            set_value_at_indices_int
+       procedure (bmif_set_value_at_indices_float), deferred :: &
+            set_value_at_indices_float
+       procedure (bmif_set_value_at_indices_double), deferred :: &
+            set_value_at_indices_double
+  end type bmi
+
+  abstract interface
+
+     ! Get the name of the model.
+     function bmif_get_component_name(self, name) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), pointer, intent(out) :: name
+       integer :: bmi_status
+     end function bmif_get_component_name
+
+     ! List a model's input variables.
+     function bmif_get_input_var_names(self, names) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), pointer, intent(out) :: names(:)
+       integer :: bmi_status
+     end function bmif_get_input_var_names
+
+     ! List a model's output variables.
+     function bmif_get_output_var_names(self, names) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), pointer, intent(out) :: names(:)
+       integer :: bmi_status
+     end function bmif_get_output_var_names
+
+     ! Perform startup tasks for the model.
+     function bmif_initialize(self, config_file) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(out) :: self
+       character (len=*), intent(in) :: config_file
+       integer :: bmi_status
+     end function bmif_initialize
+
+     ! Perform teardown tasks for the model.
+     function bmif_finalize(self) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       integer :: bmi_status
+     end function bmif_finalize
+
+     ! Start time of the model.
+     function bmif_get_start_time(self, time) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       double precision, intent(out) :: time
+       integer :: bmi_status
+     end function bmif_get_start_time
+
+     ! End time of the model.
+     function bmif_get_end_time(self, time) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       double precision, intent(out) :: time
+       integer :: bmi_status
+     end function bmif_get_end_time
+
+     ! Current time of the model.
+     function bmif_get_current_time(self, time) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       double precision, intent(out) :: time
+       integer :: bmi_status
+     end function bmif_get_current_time
+
+     ! Time step of the model.
+     function bmif_get_time_step(self, time_step) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       double precision, intent(out) :: time_step
+       integer :: bmi_status
+     end function bmif_get_time_step
+
+     ! Time units of the model.
+     function bmif_get_time_units(self, time_units) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(out) :: time_units
+       integer :: bmi_status
+     end function bmif_get_time_units
+
+     ! Advance the model one time step.
+     function bmif_update(self) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       integer :: bmi_status
+     end function bmif_update
+
+     ! Advance the model by a fraction of a time step.
+     function bmif_update_frac(self, time_frac) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       double precision, intent(in) :: time_frac
+       integer :: bmi_status
+     end function bmif_update_frac
+
+     ! Advance the model until the given time.
+     function bmif_update_until(self, time) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       double precision, intent(in) :: time
+       integer :: bmi_status
+     end function bmif_update_until
+
+     ! Get the grid identifier for the given variable.
+     function bmif_get_var_grid(self, var_name, grid_id) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(out) :: grid_id
+       integer :: bmi_status
+     end function bmif_get_var_grid
+
+     ! Get the grid type as a string.
+     function bmif_get_grid_type(self, grid_id, grid_type) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       character (len=*), intent(out) :: grid_type
+       integer :: bmi_status
+     end function bmif_get_grid_type
+
+     ! Get number of dimensions of the computational grid.
+     function bmif_get_grid_rank(self, grid_id, grid_rank) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       integer, intent(out) :: grid_rank
+       integer :: bmi_status
+     end function bmif_get_grid_rank
+
+     ! Get the dimensions of the computational grid.
+     function bmif_get_grid_shape(self, grid_id, grid_shape) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       integer, dimension(:), intent(out) :: grid_shape
+       integer :: bmi_status
+     end function bmif_get_grid_shape
+
+     ! Get the total number of elements in the computational grid.
+     function bmif_get_grid_size(self, grid_id, grid_size) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       integer, intent(out) :: grid_size
+       integer :: bmi_status
+     end function bmif_get_grid_size
+
+     ! Get distance between nodes of the computational grid.
+     function bmif_get_grid_spacing(self, grid_id, grid_spacing) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       real, dimension(:), intent(out) :: grid_spacing
+       integer :: bmi_status
+     end function bmif_get_grid_spacing
+
+     ! Get coordinates of the origin of the computational grid.
+     function bmif_get_grid_origin(self, grid_id, grid_origin) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       real, dimension(:), intent(out) :: grid_origin
+       integer :: bmi_status
+     end function bmif_get_grid_origin
+
+     ! Get the x-coordinates of the nodes of a computational grid.
+     function bmif_get_grid_x(self, grid_id, grid_x) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       real, dimension(:), intent(out) :: grid_x
+       integer :: bmi_status
+     end function bmif_get_grid_x
+
+     ! Get the y-coordinates of the nodes of a computational grid.
+     function bmif_get_grid_y(self, grid_id, grid_y) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       real, dimension(:), intent(out) :: grid_y
+       integer :: bmi_status
+     end function bmif_get_grid_y
+
+     ! Get the z-coordinates of the nodes of a computational grid.
+     function bmif_get_grid_z(self, grid_id, grid_z) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       real, dimension(:), intent(out) :: grid_z
+       integer :: bmi_status
+     end function bmif_get_grid_z
+
+     ! Get the connectivity array of the nodes of an unstructured grid.
+     function bmif_get_grid_connectivity(self, grid_id, grid_conn) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       integer, dimension(:), intent(out) :: grid_conn
+       integer :: bmi_status
+     end function bmif_get_grid_connectivity
+
+     ! Get the offsets of the nodes of an unstructured grid.
+     function bmif_get_grid_offset(self, grid_id, grid_offset) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       integer, intent(in) :: grid_id
+       integer, dimension(:), intent(out) :: grid_offset
+       integer :: bmi_status
+     end function bmif_get_grid_offset
+
+     ! Get the data type of the given variable as a string.
+     function bmif_get_var_type(self, var_name, var_type) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       character (len=*), intent(out) :: var_type
+       integer :: bmi_status
+     end function bmif_get_var_type
+
+     ! Get the units of the given variable.
+     function bmif_get_var_units(self, var_name, var_units) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       character (len=*), intent(out) :: var_units
+       integer :: bmi_status
+     end function bmif_get_var_units
+
+     ! Get memory use per array element, in bytes.
+     function bmif_get_var_itemsize(self, var_name, var_size) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(out) :: var_size
+       integer :: bmi_status
+     end function bmif_get_var_itemsize
+
+     ! Get size of the given variable, in bytes.
+     function bmif_get_var_nbytes(self, var_name, var_nbytes) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(out) :: var_nbytes
+       integer :: bmi_status
+     end function bmif_get_var_nbytes
+
+     ! Get a copy of values (flattened!) of the given integer variable.
+     function bmif_get_value_int(self, var_name, dest) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_int
+
+     ! Get a copy of values (flattened!) of the given real variable.
+     function bmif_get_value_float(self, var_name, dest) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       real, intent(inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_float
+
+     ! Get a copy of values (flattened!) of the given double variable.
+     function bmif_get_value_double(self, var_name, dest) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       double precision, intent(inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_double
+
+     ! Get a reference to the given integer variable.
+     function bmif_get_value_ref_int(self, var_name, dest) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       integer, pointer, intent(inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_ref_int
+
+     ! Get a reference to the given real variable.
+     function bmif_get_value_ref_float(self, var_name, dest) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       real, pointer, intent(inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_ref_float
+
+     ! Get a reference to the given double variable.
+     function bmif_get_value_ref_double(self, var_name, dest) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       double precision, pointer, intent(inout) :: dest(:)
+       integer :: bmi_status
+     end function bmif_get_value_ref_double
+
+     ! Get integer values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_int(self, var_name, dest, indices) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(inout) :: dest(:)
+       integer, intent(in) :: indices(:)
+       integer :: bmi_status
+     end function bmif_get_value_at_indices_int
+
+     ! Get real values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_float(self, var_name, dest, indices) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       real, intent(inout) :: dest(:)
+       integer, intent(in) :: indices(:)
+       integer :: bmi_status
+     end function bmif_get_value_at_indices_float
+
+     ! Get double values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_double(self, var_name, dest, indices) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(in) :: self
+       character (len=*), intent(in) :: var_name
+       double precision, intent(inout) :: dest(:)
+       integer, intent(in) :: indices(:)
+       integer :: bmi_status
+     end function bmif_get_value_at_indices_double
+
+     ! Set new values for an integer model variable.
+     function bmif_set_value_int(self, var_name, src) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_int
+
+     ! Set new values for a real model variable.
+     function bmif_set_value_float(self, var_name, src) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       character (len=*), intent(in) :: var_name
+       real, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_float
+
+     ! Set new values for a double model variable.
+     function bmif_set_value_double(self, var_name, src) result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       character (len=*), intent(in) :: var_name
+       double precision, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_double
+
+     ! Set integer values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_int(self, var_name, indices, src) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(in) :: indices(:)
+       integer, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_int
+
+     ! Set real values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_float(self, var_name, indices, src) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(in) :: indices(:)
+       real, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_float
+
+     ! Set double values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_double(self, var_name, indices, src) &
+          result(bmi_status)
+       import :: bmi
+       class (bmi), intent(inout) :: self
+       character (len=*), intent(in) :: var_name
+       integer, intent(in) :: indices(:)
+       double precision, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_double
+
+  end interface
+
+end module bmif

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi.f90
@@ -44,9 +44,9 @@ module bmif
        procedure (bmif_get_value_int), deferred :: get_value_int
        procedure (bmif_get_value_float), deferred :: get_value_float
        procedure (bmif_get_value_double), deferred :: get_value_double
-       procedure (bmif_get_value_ref_int), deferred :: get_value_ref_int
-       procedure (bmif_get_value_ref_float), deferred :: get_value_ref_float
-       procedure (bmif_get_value_ref_double), deferred :: get_value_ref_double
+       procedure (bmif_get_value_ptr_int), deferred :: get_value_ptr_int
+       procedure (bmif_get_value_ptr_float), deferred :: get_value_ptr_float
+       procedure (bmif_get_value_ptr_double), deferred :: get_value_ptr_double
        procedure (bmif_get_value_at_indices_int), deferred :: &
             get_value_at_indices_int
        procedure (bmif_get_value_at_indices_float), deferred :: &
@@ -218,7 +218,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_spacing
+       double precision, dimension(:), intent(out) :: grid_spacing
        integer :: bmi_status
      end function bmif_get_grid_spacing
 
@@ -227,7 +227,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_origin
+       double precision, dimension(:), intent(out) :: grid_origin
        integer :: bmi_status
      end function bmif_get_grid_origin
 
@@ -236,7 +236,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_x
+       double precision, dimension(:), intent(out) :: grid_x
        integer :: bmi_status
      end function bmif_get_grid_x
 
@@ -245,7 +245,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_y
+       double precision, dimension(:), intent(out) :: grid_y
        integer :: bmi_status
      end function bmif_get_grid_y
 
@@ -254,7 +254,7 @@ module bmif
        import :: bmi
        class (bmi), intent(in) :: self
        integer, intent(in) :: grid_id
-       real, dimension(:), intent(out) :: grid_z
+       double precision, dimension(:), intent(out) :: grid_z
        integer :: bmi_status
      end function bmif_get_grid_z
 
@@ -342,34 +342,34 @@ module bmif
      end function bmif_get_value_double
 
      ! Get a reference to the given integer variable.
-     function bmif_get_value_ref_int(self, var_name, dest) &
+     function bmif_get_value_ptr_int(self, var_name, dest) &
           result(bmi_status)
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
        integer, pointer, intent(inout) :: dest(:)
        integer :: bmi_status
-     end function bmif_get_value_ref_int
+     end function bmif_get_value_ptr_int
 
      ! Get a reference to the given real variable.
-     function bmif_get_value_ref_float(self, var_name, dest) &
+     function bmif_get_value_ptr_float(self, var_name, dest) &
           result(bmi_status)
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
        real, pointer, intent(inout) :: dest(:)
        integer :: bmi_status
-     end function bmif_get_value_ref_float
+     end function bmif_get_value_ptr_float
 
      ! Get a reference to the given double variable.
-     function bmif_get_value_ref_double(self, var_name, dest) &
+     function bmif_get_value_ptr_double(self, var_name, dest) &
           result(bmi_status)
        import :: bmi
        class (bmi), intent(in) :: self
        character (len=*), intent(in) :: var_name
        double precision, pointer, intent(inout) :: dest(:)
        integer :: bmi_status
-     end function bmif_get_value_ref_double
+     end function bmif_get_value_ptr_double
 
      ! Get integer values at particular (one-dimensional) indices.
      function bmif_get_value_at_indices_int(self, var_name, dest, indices) &

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -3,19 +3,21 @@
 !
 module bmi_interoperability
 
+{%- set entry_point = cookiecutter.entry_points.split(',')[0] %}
+{%- set pymt_class = entry_point.split('=')[0] %}
+{%- set plugin_module, plugin_class = entry_point.split('=')[1].split(':') %}
+
   use, intrinsic :: iso_c_binding
 
 {%- for lib in cookiecutter.libraries.split(',') %}
   use {{ lib }}
-{% endfor %}
+{%- endfor %}
+  use {{ plugin_module }}
 
   implicit none
 
-{%- set plugin_module =
-  cookiecutter.entry_points.split(',')[0].split('=')[1].split(':')[0] %}
-
   integer, parameter :: N_MODELS = 10
-  type ({{ plugin_module }}) :: model_array(N_MODELS)
+  type ({{ plugin_class }}) :: model_array(N_MODELS)
   logical :: model_avail(N_MODELS) = .true.
 
 contains

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -358,7 +358,7 @@ contains
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(in), value :: grid_id
     integer (c_int), intent(in), value :: n
-    real (c_float), intent(out) :: grid_spacing(n)
+    real (c_double), intent(out) :: grid_spacing(n)
     integer (c_int) :: status
 
     status = model_array(model_index)%get_grid_spacing(grid_id, grid_spacing)
@@ -372,7 +372,7 @@ contains
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(in), value :: grid_id
     integer (c_int), intent(in), value :: n
-    real (c_float), intent(out) :: grid_origin(n)
+    real (c_double), intent(out) :: grid_origin(n)
     integer (c_int) :: status
 
     status = model_array(model_index)%get_grid_origin(grid_id, grid_origin)
@@ -386,7 +386,7 @@ contains
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(in), value :: grid_id
     integer (c_int), intent(in), value :: n
-    real (c_float), intent(out) :: grid_x(n)
+    real (c_double), intent(out) :: grid_x(n)
     integer (c_int) :: status
 
     status = model_array(model_index)%get_grid_x(grid_id, grid_x)
@@ -400,7 +400,7 @@ contains
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(in), value :: grid_id
     integer (c_int), intent(in), value :: n
-    real (c_float), intent(out) :: grid_y(n)
+    real (c_double), intent(out) :: grid_y(n)
     integer (c_int) :: status
 
     status = model_array(model_index)%get_grid_y(grid_id, grid_y)
@@ -414,7 +414,7 @@ contains
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(in), value :: grid_id
     integer (c_int), intent(in), value :: n
-    real (c_float), intent(out) :: grid_z(n)
+    real (c_double), intent(out) :: grid_z(n)
     integer (c_int) :: status
 
     status = model_array(model_index)%get_grid_z(grid_id, grid_z)

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -5,7 +5,7 @@ module bmi_interoperability
 
   use, intrinsic :: iso_c_binding
 
-{%- for lib in cookiecutter.libraries %}
+{%- for lib in cookiecutter.libraries.split(',') %}
   use {{ lib }}
 {% endfor %}
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -1,0 +1,725 @@
+!
+! This is the interoperability layer for the Fortran BMI.
+!
+module bmi_interoperability
+
+  use, intrinsic :: iso_c_binding
+
+{%- for lib in cookiecutter.libraries %}
+  use {{ lib }}
+{% endfor %}
+
+  implicit none
+
+{%- set plugin_module =
+  cookiecutter.entry_points.split(',')[0].split('=')[1].split(':')[0] %}
+
+  integer, parameter :: N_MODELS = 10
+  type ({{ plugin_module }}) :: model_array(N_MODELS)
+  logical :: model_avail(N_MODELS) = .true.
+
+contains
+
+  !
+  ! Find the next unused model index in the array.
+  !
+  function bmi_new() bind(c) result(model_index)
+    integer (c_int) :: model_index
+    integer :: i
+
+    model_index = -1
+    do i = 1, N_MODELS
+       if (model_avail(i)) then
+          model_avail(i) = .false.
+          model_index = i
+          exit
+       end if
+    end do
+  end function bmi_new
+
+  !
+  ! Initialize one model in the array, based on the input index.
+  !
+  function bmi_initialize(model_index, config_file, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: config_file(n)
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: config_file_
+
+    ! Convert `config_file` from rank-1 array to scalar.
+    do i = 1, n
+       config_file_(i:i) = config_file(i)
+    enddo
+
+    status = model_array(model_index)%initialize(config_file_)
+  end function bmi_initialize
+
+  !
+  ! Clean up one model in the array.
+  !
+  function bmi_finalize(model_index) bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int) :: status
+
+    status = model_array(model_index)%finalize()
+    model_avail(model_index) = .true.
+  end function bmi_finalize
+
+  !
+  ! Get the component name attribute.
+  !
+  function bmi_get_component_name(model_index, name, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(out) :: name(n)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char), pointer :: pname
+    character (len=n, kind=c_char) :: name_
+
+    status = model_array(model_index)%get_component_name(pname)
+
+    ! Cast `pname` back to a string, dereferences `pname`.
+    name_ = pname
+
+    ! Load the `name_` string, trimmed, back into `name` for output.
+    do i = 1, len(trim(name_))
+        name(i) = name_(i:i)
+    enddo
+    name = name//C_NULL_CHAR
+  end function bmi_get_component_name
+
+  !
+  ! Get the number of input variables.
+  !
+  function bmi_get_input_var_name_count(model_index, count) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(out) :: count
+    integer (c_int) :: status
+    character (len=BMI_MAX_VAR_NAME), pointer :: pnames(:)
+
+    status = model_array(model_index)%get_input_var_names(pnames)
+    count = size(pnames)
+    status = BMI_SUCCESS
+  end function bmi_get_input_var_name_count
+
+  !
+  ! Get the names of the input variables.
+  !
+  function bmi_get_input_var_names(model_index, names, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    type (c_ptr),  intent(out) :: names(n)
+    integer (c_int) :: status, i
+    character (len=BMI_MAX_VAR_NAME), dimension(:), pointer :: pnames
+
+    status = model_array(model_index)%get_input_var_names(pnames)
+
+    do i = 1, n
+       pnames(i) = trim(pnames(i))//C_NULL_CHAR
+       names(i) = c_loc(pnames(i))
+    enddo
+  end function bmi_get_input_var_names
+
+  !
+  ! Get the number of output variables.
+  !
+  function bmi_get_output_var_name_count(model_index, count) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(out) :: count
+    integer (c_int) :: status
+    character (len=BMI_MAX_VAR_NAME), pointer :: pnames(:)
+
+    status = model_array(model_index)%get_output_var_names(pnames)
+    count = size(pnames)
+    status = BMI_SUCCESS
+  end function bmi_get_output_var_name_count
+
+  !
+  ! Get the names of the output variables.
+  !
+  function bmi_get_output_var_names(model_index, names, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    type (c_ptr),  intent(out) :: names(n)
+    integer (c_int) :: status, i
+    character (len=BMI_MAX_VAR_NAME), dimension(:), pointer :: pnames
+
+    status = model_array(model_index)%get_output_var_names(pnames)
+
+    do i = 1, n
+       pnames(i) = trim(pnames(i))//C_NULL_CHAR
+       names(i) = c_loc(pnames(i))
+    enddo
+  end function bmi_get_output_var_names
+
+  !
+  ! Get the model start time.
+  !
+  function bmi_get_start_time(model_index, time) bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    real (c_double), intent(out) :: time
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_start_time(time)
+  end function bmi_get_start_time
+
+  !
+  ! Get the model stop time.
+  !
+  function bmi_get_end_time(model_index, time) bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    real (c_double), intent(out) :: time
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_end_time(time)
+  end function bmi_get_end_time
+
+  !
+  ! Get the current model time.
+  !
+  function bmi_get_current_time(model_index, time) bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    real (c_double), intent(out) :: time
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_current_time(time)
+  end function bmi_get_current_time
+
+  !
+  ! Get the model time step.
+  !
+  function bmi_get_time_step(model_index, time_step) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    real (c_double), intent(out) :: time_step
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_time_step(time_step)
+  end function bmi_get_time_step
+
+  !
+  ! Get the model time units.
+  !
+  function bmi_get_time_units(model_index, time_units, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(out) :: time_units(n)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: time_units_
+
+    ! Convert `time_units` from rank-1 array to scalar.
+    do i = 1, n
+       time_units_(i:i) = time_units(i)
+    enddo
+
+    status = model_array(model_index)%get_time_units(time_units_)
+
+    ! Load the `time_units_` result back into `time_units` for output.
+    do i = 1, len(trim(time_units_))
+        time_units(i) = time_units_(i:i)
+    enddo
+    time_units = time_units//C_NULL_CHAR
+  end function bmi_get_time_units
+
+  !
+  ! Advance the model by one time step.
+  !
+  function bmi_update(model_index) bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int) :: status
+
+    status = model_array(model_index)%update()
+  end function bmi_update
+
+  !
+  ! Advance the model by a fraction of a time step.
+  !
+  function bmi_update_frac(model_index, time_frac) bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    real (c_double), intent(in), value :: time_frac
+    integer (c_int) :: status
+
+    status = model_array(model_index)%update_frac(time_frac)
+  end function bmi_update_frac
+
+  !
+  ! Advance the model to a time in the future.
+  !
+  function bmi_update_until(model_index, time_later) bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    real (c_double), intent(in), value :: time_later
+    integer (c_int) :: status
+
+    status = model_array(model_index)%update_until(time_later)
+  end function bmi_update_until
+
+  !
+  ! Get the grid identifier for a given variable.
+  !
+  function bmi_get_var_grid(model_index, var_name, n, grid_id) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(out) :: grid_id
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    ! Convert `var_name` from rank-1 array to scalar.
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%get_var_grid(var_name_, grid_id)
+  end function bmi_get_var_grid
+
+  !
+  ! Get the grid type for the specified variable.
+  !
+  function bmi_get_grid_type(model_index, grid_id, grid_type, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(out) :: grid_type(n)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: grid_type_
+
+    do i = 1, n
+       grid_type_(i:i) = grid_type(i)
+    enddo
+
+    status = model_array(model_index)%get_grid_type(grid_id, grid_type_)
+
+    do i = 1, len(trim(grid_type_))
+        grid_type(i) = grid_type_(i:i)
+    enddo
+    grid_type = grid_type//C_NULL_CHAR
+  end function bmi_get_grid_type
+
+  !
+  ! Get the number of dimensions of a grid.
+  !
+  function bmi_get_grid_rank(model_index, grid_id, grid_rank) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(out) :: grid_rank
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_rank(grid_id, grid_rank)
+  end function bmi_get_grid_rank
+
+  !
+  ! Get the dimensions of a grid.
+  !
+  function bmi_get_grid_shape(model_index, grid_id, grid_shape, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    integer (c_int), intent(out) :: grid_shape(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_shape(grid_id, grid_shape)
+  end function bmi_get_grid_shape
+
+  !
+  ! Get the total number of elements in a grid.
+  !
+  function bmi_get_grid_size(model_index, grid_id, grid_size) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(out) :: grid_size
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_size(grid_id, grid_size)
+  end function bmi_get_grid_size
+
+  !
+  ! Get the spacing between grid elements in each dimension.
+  !
+  function bmi_get_grid_spacing(model_index, grid_id, grid_spacing, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    real (c_float), intent(out) :: grid_spacing(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_spacing(grid_id, grid_spacing)
+  end function bmi_get_grid_spacing
+
+  !
+  ! Get the origin of the grid.
+  !
+  function bmi_get_grid_origin(model_index, grid_id, grid_origin, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    real (c_float), intent(out) :: grid_origin(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_origin(grid_id, grid_origin)
+  end function bmi_get_grid_origin
+
+  !
+  ! Get the x-coordinates of a grid's nodes.
+  !
+  function bmi_get_grid_x(model_index, grid_id, grid_x, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    real (c_float), intent(out) :: grid_x(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_x(grid_id, grid_x)
+  end function bmi_get_grid_x
+
+  !
+  ! Get the y-coordinates of a grid's nodes.
+  !
+  function bmi_get_grid_y(model_index, grid_id, grid_y, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    real (c_float), intent(out) :: grid_y(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_y(grid_id, grid_y)
+  end function bmi_get_grid_y
+
+  !
+  ! Get the z-coordinates of a grid's nodes.
+  !
+  function bmi_get_grid_z(model_index, grid_id, grid_z, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    real (c_float), intent(out) :: grid_z(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_z(grid_id, grid_z)
+  end function bmi_get_grid_z
+
+  !
+  ! Get the connectivity of a grid's nodes.
+  !
+  function bmi_get_grid_connectivity(model_index, grid_id, grid_conn, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    integer (c_int), intent(out) :: grid_conn(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_connectivity(grid_id, grid_conn)
+  end function bmi_get_grid_connectivity
+
+  !
+  ! Get the offset of a grid's nodes.
+  !
+  function bmi_get_grid_offset(model_index, grid_id, grid_offset, n) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: grid_id
+    integer (c_int), intent(in), value :: n
+    integer (c_int), intent(out) :: grid_offset(n)
+    integer (c_int) :: status
+
+    status = model_array(model_index)%get_grid_offset(grid_id, grid_offset)
+  end function bmi_get_grid_offset
+
+  !
+  ! Get the type for the specified variable.
+  !
+  function bmi_get_var_type(model_index, var_name, n, var_type, m) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    character (len=1, kind=c_char), intent(out) :: var_type(m)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+    character (len=m, kind=c_char) :: var_type_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+    do i = 1, m
+       var_type_(i:i) = var_type(i)
+    enddo
+
+    status = model_array(model_index)%get_var_type(var_name_, var_type_)
+
+    do i = 1, len(trim(var_type_))
+        var_type(i) = var_type_(i:i)
+    enddo
+    var_type = var_type//C_NULL_CHAR
+  end function bmi_get_var_type
+
+  !
+  ! Get the units for the specified variable.
+  !
+  function bmi_get_var_units(model_index, var_name, n, var_units, m) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    character (len=1, kind=c_char), intent(out) :: var_units(m)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+    character (len=m, kind=c_char) :: var_units_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+    do i = 1, m
+       var_units_(i:i) = var_units(i)
+    enddo
+
+    status = model_array(model_index)%get_var_units(var_name_, var_units_)
+
+    do i = 1, len(trim(var_units_))
+        var_units(i) = var_units_(i:i)
+    enddo
+    var_units = var_units//C_NULL_CHAR
+  end function bmi_get_var_units
+
+  !
+  ! Get the size of a single element of the specified variable.
+  !
+  function bmi_get_var_itemsize(model_index, var_name, n, var_itemsize) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(out) :: var_itemsize
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%get_var_itemsize(var_name_, var_itemsize)
+  end function bmi_get_var_itemsize
+
+  !
+  ! Get the total number of bytes used by the specified variable.
+  !
+  function bmi_get_var_nbytes(model_index, var_name, n, var_nbytes) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(out) :: var_nbytes
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%get_var_nbytes(var_name_, var_nbytes)
+  end function bmi_get_var_nbytes
+
+  !
+  ! Get a copy of an integer variable's values, flattened.
+  !
+  function bmi_get_value_int(model_index, var_name, n, buffer, m) &
+       bind(c) result(status) ! (2)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    integer (c_int), intent(out) :: buffer(m) ! (1)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%get_value(var_name_, buffer)
+  end function bmi_get_value_int
+
+  !
+  ! Get a copy of a float variable's values, flattened.
+  !
+  function bmi_get_value_float(model_index, var_name, n, buffer, m) &
+       bind(c) result(status) ! (2)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    real (c_float), intent(out) :: buffer(m)  ! (1)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%get_value(var_name_, buffer)
+    ! write(*,*) "Fortran"
+    ! write(*,'(8f6.2)') buffer
+    ! write(*,'(48f6.1)') buffer
+
+    ! (1) Can't have assumed-shape array `buffer(:)` with bind(c).
+    ! (2) Can't have type-bound (therefore generic) procedures with bind(c).
+  end function bmi_get_value_float
+
+  !
+  ! Get a copy of a double precision variable's values, flattened.
+  !
+  function bmi_get_value_double(model_index, var_name, n, buffer, m) &
+       bind(c) result(status) ! (2)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    real (c_double), intent(out) :: buffer(m)  ! (1)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%get_value(var_name_, buffer)
+  end function bmi_get_value_double
+
+  !
+  ! Get a reference to a variable's values.
+  !
+  function bmi_get_value_ref(model_index, var_name, n, ref) &
+       bind(c) result(status)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    type (c_ptr), intent(out) :: ref
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+    character (len=BMI_MAX_TYPE_NAME, kind=c_char) :: var_type
+    integer, pointer :: idest(:)
+    real, pointer :: rdest(:)
+    double precision, pointer :: ddest(:)
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%get_var_type(var_name_, var_type)
+
+    select case(var_type)
+    case("integer")
+       status = model_array(model_index)%get_value_ref(var_name_, idest)
+       ref = c_loc(idest(1))
+       status = BMI_SUCCESS
+    case("real")
+       status = model_array(model_index)%get_value_ref(var_name_, rdest)
+       ref = c_loc(rdest(1))
+       status = BMI_SUCCESS
+    case("double precision")
+       status = model_array(model_index)%get_value_ref(var_name_, ddest)
+       ref = c_loc(ddest(1))
+       status = BMI_SUCCESS
+    case default
+       status = BMI_FAILURE
+    end select
+  end function bmi_get_value_ref
+
+  !
+  ! Set an integer variable's values.
+  !
+  function bmi_set_value_int(model_index, var_name, n, buffer, m) &
+       bind(c) result(status) ! (2)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    integer (c_int), intent(in) :: buffer(m) ! (1)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%set_value(var_name_, buffer)
+  end function bmi_set_value_int
+
+  !
+  ! Set a float variable's values.
+  !
+  function bmi_set_value_float(model_index, var_name, n, buffer, m) &
+       bind(c) result(status) ! (2)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    real (c_float), intent(in) :: buffer(m) ! (1)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%set_value(var_name_, buffer)
+
+    ! (1) Can't have assumed-shape array `buffer(:)` with bind(c).
+    ! (2) Can't have type-bound (therefore generic) procedures with bind(c).
+  end function bmi_set_value_float
+
+  !
+  ! Set a double precision variable's values.
+  !
+  function bmi_set_value_double(model_index, var_name, n, buffer, m) &
+       bind(c) result(status) ! (2)
+    integer (c_int), intent(in), value :: model_index
+    integer (c_int), intent(in), value :: n
+    character (len=1, kind=c_char), intent(in) :: var_name(n)
+    integer (c_int), intent(in), value :: m
+    real (c_double), intent(in) :: buffer(m) ! (1)
+
+    integer (c_int) :: i, status
+    character (len=n, kind=c_char) :: var_name_
+
+    do i = 1, n
+       var_name_(i:i) = var_name(i)
+    enddo
+
+    status = model_array(model_index)%set_value(var_name_, buffer)
+  end function bmi_set_value_double
+
+end module bmi_interoperability

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -16,7 +16,7 @@ module bmi_interoperability
 
   implicit none
 
-  integer, parameter :: N_MODELS = 10
+  integer, parameter :: N_MODELS = 2048
   type ({{ plugin_class }}) :: model_array(N_MODELS)
   logical :: model_avail(N_MODELS) = .true.
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -620,7 +620,7 @@ contains
   !
   ! Get a reference to a variable's values.
   !
-  function bmi_get_value_ref(model_index, var_name, n, ref) &
+  function bmi_get_value_ptr(model_index, var_name, n, ref) &
        bind(c) result(status)
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(in), value :: n
@@ -642,21 +642,21 @@ contains
 
     select case(var_type)
     case("integer")
-       status = model_array(model_index)%get_value_ref(var_name_, idest)
+       status = model_array(model_index)%get_value_ptr(var_name_, idest)
        ref = c_loc(idest(1))
        status = BMI_SUCCESS
     case("real")
-       status = model_array(model_index)%get_value_ref(var_name_, rdest)
+       status = model_array(model_index)%get_value_ptr(var_name_, rdest)
        ref = c_loc(rdest(1))
        status = BMI_SUCCESS
     case("double precision")
-       status = model_array(model_index)%get_value_ref(var_name_, ddest)
+       status = model_array(model_index)%get_value_ptr(var_name_, ddest)
        ref = c_loc(ddest(1))
        status = BMI_SUCCESS
     case default
        status = BMI_FAILURE
     end select
-  end function bmi_get_value_ref
+  end function bmi_get_value_ptr
 
   !
   ! Set an integer variable's values.

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -35,12 +35,12 @@ int bmi_get_grid_type(int model, int grid_id, char *type, int n_chars);
 int bmi_get_grid_rank(int model, int grid_id, int *rank);
 int bmi_get_grid_shape(int model, int grid_id, int *shape, int rank);
 int bmi_get_grid_size(int model, int grid_id, int *size);
-int bmi_get_grid_spacing(int model, int grid_id, float *spacing, int rank);
-int bmi_get_grid_origin(int model, int grid_id, float *origin, int rank);
+int bmi_get_grid_spacing(int model, int grid_id, double *spacing, int rank);
+int bmi_get_grid_origin(int model, int grid_id, double *origin, int rank);
 
-int bmi_get_grid_x(int model, int grid_id, float *x, int size);
-int bmi_get_grid_y(int model, int grid_id, float *y, int size);
-int bmi_get_grid_z(int model, int grid_id, float *z, int size);
+int bmi_get_grid_x(int model, int grid_id, double *x, int size);
+int bmi_get_grid_y(int model, int grid_id, double *y, int size);
+int bmi_get_grid_z(int model, int grid_id, double *z, int size);
 int bmi_get_grid_connectivity(int model, int grid_id, int *conn, int size);
 int bmi_get_grid_offset(int model, int grid_id, int *offset, int size);
 

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -1,0 +1,70 @@
+/*
+  Function prototypes for the Fortran interoperability layer.
+*/
+
+// Max string lengths from "bmi.f90".
+#define MAX_COMPONENT_NAME (2048)
+#define MAX_VAR_NAME (2048)
+#define MAX_TYPE_NAME (2048)
+#define MAX_UNITS_NAME (2048)
+
+int bmi_new(void);
+
+int bmi_initialize(int model, const char *config_file, int n_chars);
+int bmi_update(int model);
+int bmi_update_until(int model, double until);
+int bmi_update_frac(int model, double frac);
+int bmi_finalize(int model);
+
+int bmi_get_component_name(int model, char *name, int n_chars);
+int bmi_get_input_var_name_count(int model, int *count);
+int bmi_get_output_var_name_count(int model, int *count);
+int bmi_get_input_var_names(int model, char **names, int n_names);
+int bmi_get_output_var_names(int model, char **names, int n_names);
+
+int bmi_get_start_time(int model, double *time);
+int bmi_get_end_time(int model, double *time);
+int bmi_get_current_time(int model, double *time);
+int bmi_get_time_step(int model, double *time);
+int bmi_get_time_units(int model, char *units, int n_chars);
+
+int bmi_get_var_grid(int model, const char *var_name, int n_chars,
+		     int *grid_id);
+
+int bmi_get_grid_type(int model, int grid_id, char *type, int n_chars);
+int bmi_get_grid_rank(int model, int grid_id, int *rank);
+int bmi_get_grid_shape(int model, int grid_id, int *shape, int rank);
+int bmi_get_grid_size(int model, int grid_id, int *size);
+int bmi_get_grid_spacing(int model, int grid_id, float *spacing, int rank);
+int bmi_get_grid_origin(int model, int grid_id, float *origin, int rank);
+
+int bmi_get_grid_x(int model, int grid_id, float *x, int size);
+int bmi_get_grid_y(int model, int grid_id, float *y, int size);
+int bmi_get_grid_z(int model, int grid_id, float *z, int size);
+int bmi_get_grid_connectivity(int model, int grid_id, int *conn, int size);
+int bmi_get_grid_offset(int model, int grid_id, int *offset, int size);
+
+int bmi_get_var_type(int model, const char *var_name, int n_chars,
+		     char *type, int m_chars);
+int bmi_get_var_units(int model, const char *var_name, int n_chars,
+		      char *units, int m_chars);
+int bmi_get_var_itemsize(int model, const char *var_name, int n_chars,
+			 int *itemsize);
+int bmi_get_var_nbytes(int model, const char *var_name, int n_chars,
+		       int *nbytes);
+
+int bmi_get_value_int(int model, const char *var_name, int n_chars,
+		      void *buffer, int size);
+int bmi_get_value_float(int model, const char *var_name, int n_chars,
+			void *buffer, int size);
+int bmi_get_value_double(int model, const char *var_name, int n_chars,
+			 void *buffer, int size);
+
+int bmi_get_value_ref(int model, const char *var_name, int n_chars, void **ref);
+
+int bmi_set_value_int(int model, const char *var_name, int n_chars,
+		      void *buffer, int size);
+int bmi_set_value_float(int model, const char *var_name, int n_chars,
+			void *buffer, int size);
+int bmi_set_value_double(int model, const char *var_name, int n_chars,
+			 void *buffer, int size);

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -60,7 +60,7 @@ int bmi_get_value_float(int model, const char *var_name, int n_chars,
 int bmi_get_value_double(int model, const char *var_name, int n_chars,
 			 void *buffer, int size);
 
-int bmi_get_value_ref(int model, const char *var_name, int n_chars, void **ref);
+int bmi_get_value_ptr(int model, const char *var_name, int n_chars, void **ptr);
 
 int bmi_set_value_int(int model, const char *var_name, int n_chars,
 		      void *buffer, int size);

--- a/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
+++ b/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
         {%- set plugin_class = entry_point.split('=')[0] -%}
     {%- endif %}
     - config_file=$(mmd-stage {{ plugin_class }} . > MANIFEST && mmd-query {{ plugin_class }} --var=run.config_file.path)
-    - bmi-test pymt_{{ cookiecutter.plugin_name }}.bmi:{{ plugin_class }} --infile=$config_file --manifest=MANIFEST -v
+    - bmi-test pymt_{{ cookiecutter.plugin_name }}.bmi:{{ plugin_class }} --config-file=$config_file --manifest=MANIFEST -v
 {%- endfor %}
 
 about:

--- a/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
+++ b/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
@@ -42,9 +42,9 @@ test:
   commands:
 {%- for entry_point in cookiecutter.entry_points.split(',') %}
     {%- set plugin_module, plugin_class = entry_point.split('=')[1].split(':') -%}
-    {%- if cookiecutter.language == 'c' or cookiecutter.language == 'c++' %}
+    {%- if cookiecutter.language in ['c', 'c++', 'fortran'] %}
         {%- set plugin_class = entry_point.split('=')[0] -%}
-    {%- endif %}  # TODO
+    {%- endif %}
     - config_file=$(mmd-stage {{ plugin_class }} . > MANIFEST && mmd-query {{ plugin_class }} --var=run.config_file.path)
     - bmi-test pymt_{{ cookiecutter.plugin_name }}.bmi:{{ plugin_class }} --infile=$config_file --manifest=MANIFEST -v
 {%- endfor %}

--- a/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
+++ b/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
@@ -14,6 +14,9 @@ build:
 requirements:
   build:
     - {{"{{"}} compiler('c') {{"}}"}}
+    {%- if cookiecutter.language == 'fortran' %}
+    - {{"{{"}} compiler('fortran') {{"}}"}}
+    {%- endif %}
   host:
     - python
     - pip
@@ -24,7 +27,6 @@ requirements:
     {%- for requirement in cookiecutter.plugin_requirements.split(',') %}
     - {{ requirement|trim }} {% endfor %}
     {%- endif %}
-
   run:
     - python
     - {{"{{"}} pin_compatible('numpy') {{"}}"}}

--- a/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
+++ b/pymt_{{cookiecutter.plugin_name}}/recipe/meta.yaml
@@ -44,14 +44,14 @@ test:
     {%- set plugin_module, plugin_class = entry_point.split('=')[1].split(':') -%}
     {%- if cookiecutter.language == 'c' or cookiecutter.language == 'c++' %}
         {%- set plugin_class = entry_point.split('=')[0] -%}
-    {%- endif %}
+    {%- endif %}  # TODO
     - config_file=$(mmd-stage {{ plugin_class }} . > MANIFEST && mmd-query {{ plugin_class }} --var=run.config_file.path)
     - bmi-test pymt_{{ cookiecutter.plugin_name }}.bmi:{{ plugin_class }} --infile=$config_file --manifest=MANIFEST -v
 {%- endfor %}
 
 about:
   summary: Python package that wraps the {{cookiecutter.plugin_name}} BMI.
-  home: https://github.com/mcflugen/pymt_{{cookiecutter.plugin_name}}
+  home: https://github.com/{{cookiecutter.github_username}}/pymt_{{cookiecutter.plugin_name}}
   license: {{cookiecutter.open_source_license}}
   license_file: LICENSE
-  dev_url: https://github.com/mcflugen/pymt_{{cookiecutter.plugin_name}}
+  dev_url: https://github.com/{{cookiecutter.github_username}}/pymt_{{cookiecutter.plugin_name}}

--- a/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -98,14 +98,16 @@ pymt_components = [
 {%- endfor %}
 ]
 
-{% if cookiecutter.language == 'fortran' -%}
+{% if cookiecutter.language == 'fortran' %}
 def build_interoperability():
     compiler = new_fcompiler()
     compiler.customize()
     compiler.add_include_dir(os.path.join(sys.prefix, 'lib'))
 
-    cmd = compiler.compiler_f90
+    cmd = []
+    cmd.append(compiler.compiler_f90[0])
     cmd.append(compiler.compile_switch)
+    cmd.append('-fPIC')
     for include_dir in compiler.include_dirs:
         cmd.append('-I{}'.format(include_dir))
     cmd.append('bmi_interoperability.f90')
@@ -115,12 +117,14 @@ def build_interoperability():
     except subprocess.CalledProcessError:
         raise
 
+
 class build_ext(_build_ext):
 
     def run(self):
         with cd('pymt_{{cookiecutter.plugin_name}}/lib'):
             build_interoperability()
         _build_ext.run(self)
+
 
 {% endif -%}
 

--- a/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -131,7 +131,7 @@ cmdclass["build_ext"] = build_ext
 
 setup(
     name="pymt_{{cookiecutter.plugin_name}}",
-    author="Eric Hutton",
+    author={{cookiecutter.full_name}},
     description="PyMT plugin for {{cookiecutter.plugin_name}}",
     version=versioneer.get_version(),
 {%- if cookiecutter.language in ['c', 'c++', 'fortran'] %}

--- a/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -87,7 +87,7 @@ setup(
     author="Eric Hutton",
     description="PyMT plugin {{cookiecutter.plugin_name}}",
     version=versioneer.get_version(),
-{%- if cookiecutter.language == 'c' or cookiecutter.language == 'c++' -%}
+{%- if cookiecutter.language == 'c' or cookiecutter.language == 'c++' %}
     setup_requires=["cython"],
     ext_modules=ext_modules,
 {%- endif %}

--- a/pymt_{{cookiecutter.plugin_name}}/setup.py
+++ b/pymt_{{cookiecutter.plugin_name}}/setup.py
@@ -131,7 +131,7 @@ cmdclass["build_ext"] = build_ext
 
 setup(
     name="pymt_{{cookiecutter.plugin_name}}",
-    author={{cookiecutter.full_name}},
+    author="{{cookiecutter.full_name}}",
     description="PyMT plugin for {{cookiecutter.plugin_name}}",
     version=versioneer.get_version(),
 {%- if cookiecutter.language in ['c', 'c++', 'fortran'] %}


### PR DESCRIPTION
In this PR, I've added new files and updated templates to support Fortran BMIs.

There are three outstanding issues:

- [x] The `get_value_ref` function isn't working (#11)
- [x] `bmi-test` is failing (see https://github.com/csdms/bmi/issues/26)
- [x] The conda recipe needs to be completed

What this PR does deliver is the ability to make a functioning Fortran BMI wrapper. For example, it was used to create a wrapper for the sample implementation in the bmi-fortran repo. Install with:

```
git clone git@github.com:mdpiper/pymt_heatf
cd pymt_heatf
conda install --file=requirements.txt -c conda-forge -c csdms
make install
```

Then run an example:

```
cd examples
python heatf_ex.py
```
