### PR TITLE
More updates to Fortran cookiecutter

### DIFF
--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -310,21 +310,49 @@ cdef class {{ pymt_class }}:
 
     cpdef np.ndarray get_grid_x(self, grid_id, \
                                 np.ndarray[double, ndim=1] grid_x):
-        cdef int size = self.get_grid_size(grid_id)
+        cdef int size
+
+        if self.get_grid_type(grid_id) == 'rectilinear':
+            rank = self.get_grid_rank(grid_id)
+            shape = np.ndarray(rank, dtype=np.int32)
+            size = self.get_grid_shape(grid_id, shape)[1]
+        else:
+            size = self.get_grid_size(grid_id)
+
         ok_or_raise(<int>bmi_get_grid_x(self._bmi, grid_id,
                                         &grid_x[0], size))
         return grid_x
 
     cpdef np.ndarray get_grid_y(self, grid_id, \
                                 np.ndarray[double, ndim=1] grid_y):
-        cdef int size = self.get_grid_size(grid_id)
+        cdef int size
+
+        if self.get_grid_type(grid_id) == 'rectilinear':
+            rank = self.get_grid_rank(grid_id)
+            shape = np.ndarray(rank, dtype=np.int32)
+            size = self.get_grid_shape(grid_id, shape)[0]
+        else:
+            size = self.get_grid_size(grid_id)
+
         ok_or_raise(<int>bmi_get_grid_y(self._bmi, grid_id,
                                         &grid_y[0], size))
         return grid_y
 
     cpdef np.ndarray get_grid_z(self, grid_id, \
                                 np.ndarray[double, ndim=1] grid_z):
-        cdef int size = self.get_grid_size(grid_id)
+        cdef int size
+
+        if self.get_grid_type(grid_id) == 'rectilinear':
+            rank = self.get_grid_rank(grid_id)
+            shape = np.ndarray(rank, dtype=np.int32)
+            self.get_grid_shape(grid_id, shape)
+            if rank > 2:
+                size = shape[2]
+            else:
+                size = 1
+        else:
+            size = self.get_grid_size(grid_id)
+
         ok_or_raise(<int>bmi_get_grid_z(self._bmi, grid_id,
                                         &grid_z[0], size))
         return grid_z

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -40,8 +40,8 @@ cdef extern from "bmi_interoperability.h":
     int bmi_finalize(int model)
 
     int bmi_get_component_name(int model, char *name, int n_chars)
-    int bmi_get_input_var_name_count(int model, int *count)
-    int bmi_get_output_var_name_count(int model, int *count)
+    int bmi_get_input_item_count(int model, int *count)
+    int bmi_get_output_item_count(int model, int *count)
     int bmi_get_input_var_names(int model, char **names, int n_names)
     int bmi_get_output_var_names(int model, char **names, int n_names)
 
@@ -163,9 +163,9 @@ cdef class {{ pymt_class }}:
                                                 MAX_COMPONENT_NAME))
         return to_string(self.STR_BUFFER)
 
-    cpdef int get_input_var_name_count(self):
+    cpdef int get_input_item_count(self):
         cdef int count = 0
-        ok_or_raise(<int>bmi_get_input_var_name_count(self._bmi, &count))
+        ok_or_raise(<int>bmi_get_input_item_count(self._bmi, &count))
         return count
 
     cpdef object get_input_var_names(self):
@@ -175,7 +175,7 @@ cdef class {{ pymt_class }}:
         cdef int count
         cdef int status = 1
 
-        ok_or_raise(<int>bmi_get_input_var_name_count(self._bmi, &count))
+        ok_or_raise(<int>bmi_get_input_item_count(self._bmi, &count))
 
         try:
             names = <char**>malloc(count * sizeof(char*))
@@ -196,9 +196,9 @@ cdef class {{ pymt_class }}:
 
         return tuple(py_names)
 
-    cpdef int get_output_var_name_count(self):
+    cpdef int get_output_item_count(self):
         cdef int count = 0
-        ok_or_raise(<int>bmi_get_output_var_name_count(self._bmi, &count))
+        ok_or_raise(<int>bmi_get_output_item_count(self._bmi, &count))
         return count
 
     cpdef object get_output_var_names(self):
@@ -208,7 +208,7 @@ cdef class {{ pymt_class }}:
         cdef int count
         cdef int status = 1
 
-        ok_or_raise(<int>bmi_get_output_var_name_count(self._bmi, &count))
+        ok_or_raise(<int>bmi_get_output_item_count(self._bmi, &count))
 
         try:
             names = <char**>malloc(count * sizeof(char*))

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/_fortran.pyx
@@ -290,22 +290,25 @@ cdef class {{ pymt_class }}:
     cpdef np.ndarray get_grid_shape(self, grid_id, \
                                     np.ndarray[int, ndim=1] shape):
         cdef int rank = self.get_grid_rank(grid_id)
-        ok_or_raise(<int>bmi_get_grid_shape(self._bmi, grid_id,
-                                            &shape[0], rank))
+        if rank > 0:
+            ok_or_raise(<int>bmi_get_grid_shape(self._bmi, grid_id,
+                                                &shape[0], rank))
         return shape
 
     cpdef np.ndarray get_grid_spacing(self, grid_id, \
                                       np.ndarray[double, ndim=1] spacing):
         cdef int rank = self.get_grid_rank(grid_id)
-        ok_or_raise(<int>bmi_get_grid_spacing(self._bmi, grid_id,
-                                              &spacing[0], rank))
+        if rank > 0:
+            ok_or_raise(<int>bmi_get_grid_spacing(self._bmi, grid_id,
+                                                  &spacing[0], rank))
         return spacing
 
     cpdef np.ndarray get_grid_origin(self, grid_id, \
                                      np.ndarray[double, ndim=1] origin):
         cdef int rank = self.get_grid_rank(grid_id)
-        ok_or_raise(<int>bmi_get_grid_origin(self._bmi, grid_id,
-                                             &origin[0], rank))
+        if rank > 0:
+            ok_or_raise(<int>bmi_get_grid_origin(self._bmi, grid_id,
+                                                 &origin[0], rank))
         return origin
 
     cpdef np.ndarray get_grid_x(self, grid_id, \

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.f90
@@ -100,7 +100,7 @@ contains
   !
   ! Get the number of input variables.
   !
-  function bmi_get_input_var_name_count(model_index, count) &
+  function bmi_get_input_item_count(model_index, count) &
        bind(c) result(status)
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(out) :: count
@@ -110,7 +110,7 @@ contains
     status = model_array(model_index)%get_input_var_names(pnames)
     count = size(pnames)
     status = BMI_SUCCESS
-  end function bmi_get_input_var_name_count
+  end function bmi_get_input_item_count
 
   !
   ! Get the names of the input variables.
@@ -134,7 +134,7 @@ contains
   !
   ! Get the number of output variables.
   !
-  function bmi_get_output_var_name_count(model_index, count) &
+  function bmi_get_output_item_count(model_index, count) &
        bind(c) result(status)
     integer (c_int), intent(in), value :: model_index
     integer (c_int), intent(out) :: count
@@ -144,7 +144,7 @@ contains
     status = model_array(model_index)%get_output_var_names(pnames)
     count = size(pnames)
     status = BMI_SUCCESS
-  end function bmi_get_output_var_name_count
+  end function bmi_get_output_item_count
 
   !
   ! Get the names of the output variables.

--- a/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
+++ b/pymt_{{cookiecutter.plugin_name}}/pymt_{{cookiecutter.plugin_name}}/lib/bmi_interoperability.h
@@ -16,8 +16,8 @@ int bmi_update_until(int model, double until);
 int bmi_finalize(int model);
 
 int bmi_get_component_name(int model, char *name, int n_chars);
-int bmi_get_input_var_name_count(int model, int *count);
-int bmi_get_output_var_name_count(int model, int *count);
+int bmi_get_input_item_count(int model, int *count);
+int bmi_get_output_item_count(int model, int *count);
 int bmi_get_input_var_names(int model, char **names, int n_names);
 int bmi_get_output_var_names(int model, char **names, int n_names);
 


### PR DESCRIPTION
This PR includes fixes discovered in componentizing [PRMS6 Surface](https://github.com/nhm-usgs/bmi-prms6-surface). 

* Correct names for the input and output item count functions
* Make get_grid_x, y, and z work correctly for rectilinear grids
* Guard against zero-length arrays when working with scalar grids